### PR TITLE
認証失敗時のメッセージを修正

### DIFF
--- a/handler/auth.go
+++ b/handler/auth.go
@@ -65,14 +65,14 @@ func Login(c echo.Context) error {
 	if user.ID == 0 {
 		return &echo.HTTPError{
 			Code:    http.StatusUnauthorized,
-			Message: "invalid name",
+			Message: "invalid name or password",
 		}
 	}
   if err := bcrypt.CompareHashAndPassword([]byte(user.Password), []byte(u.Password)); err != nil {
     // 失敗
 		return &echo.HTTPError{
 			Code:    http.StatusUnauthorized,
-			Message: "invalid password",
+			Message: "invalid name or password",
 		}
   }
 


### PR DESCRIPTION
認証失敗時のレスポンスを見ると，間違えていたのがユーザー名かパスワードか分かるようになっていました
これでは攻撃者に情報を与えることになってしまうため，レスポンスのメッセージを変更しました．
参考：https://www.ipa.go.jp/security/awareness/vendor/programmingv2/contents/c605.html