### PR TITLE
Fix: api で return するときに，user.password を返さないように変更

### DIFF
--- a/handler/auth.go
+++ b/handler/auth.go
@@ -51,8 +51,7 @@ func Signup(c echo.Context) error {
   }
   user.Password = string(hash)
 	model.CreateUser(user)
-	user.Password = ""
-	return c.JSON(http.StatusCreated, user)
+	return c.JSON(http.StatusCreated, user.IntoReturnUser())
 }
 
 func Login(c echo.Context) error {

--- a/handler/user.go
+++ b/handler/user.go
@@ -19,7 +19,7 @@ func GetUser(c echo.Context) error {
 		return echo.ErrNotFound
 	}
 	user := model.FindUser(&model.User{ID: UserID})
-	return c.JSON(http.StatusOK, user)
+	return c.JSON(http.StatusOK, user.IntoReturnUser())
 }
 
 // ユーザをページ取得する
@@ -34,13 +34,14 @@ func GetUsersWithPage(c echo.Context) error {
 	}
 	mode := "favorite_sum desc"
 
-    if modeId == 2 {
-      mode = "favorite_question desc"
-    } else if modeId == 3 {
-      mode = "favorite_answer desc"
-    }
+  if modeId == 2 {
+    mode = "favorite_question desc"
+  } else if modeId == 3 {
+    mode = "favorite_answer desc"
+  }
+
 	users := model.FindUsersWithPage(&model.User{}, PageID, PageLength, mode)
-	return c.JSON(http.StatusOK, users)
+	return c.JSON(http.StatusOK, users.IntoReturnUsers())
 }
 
 // user を削除する

--- a/model/user.go
+++ b/model/user.go
@@ -10,8 +10,36 @@ type User struct {
 	FavoriteSum int `json:"favorite_sum"`
 }
 
+// パスワードは json として送る必要がない
+type ReturnUser struct {
+	ID       int    `json:"id" gorm:"praimaly_key"`
+	Name     string `json:"name"`
+	FavoriteAnswer int    `json:"favorite_answer"`
+	FavoriteQuestion int  `json:"favorite_question"`
+	FavoriteSum int `json:"favorite_sum"`
+}
+
+func (u User) IntoReturnUser() ReturnUser {
+  var retUser ReturnUser
+  retUser.ID = u.ID
+  retUser.Name = u.Name
+  retUser.FavoriteAnswer = u.FavoriteAnswer
+  retUser.FavoriteQuestion = u.FavoriteQuestion
+  retUser.FavoriteSum = u.FavoriteSum
+  return retUser
+}
+
 // User の配列として定義
 type Users []User
+type ReturnUsers []ReturnUser
+
+func (users Users) IntoReturnUsers() ReturnUsers {
+  var retUsers ReturnUsers
+  for _, s := range users {
+    retUsers = append(retUsers, s.IntoReturnUser())
+  }
+  return retUsers
+}
 
 func CreateUser(user *User) {
 	db.Create(user)


### PR DESCRIPTION
# WHY
#78 参照

# WHAT
return 用の構造体を用意．
```
// パスワードは json として送る必要がない
type ReturnUser struct {
	ID       int    `json:"id" gorm:"praimaly_key"`
	Name     string `json:"name"`
	FavoriteAnswer int    `json:"favorite_answer"`
	FavoriteQuestion int  `json:"favorite_question"`
	FavoriteSum int `json:"favorite_sum"`
}
```

`c.JSON(..., user)` を `c.JSON(..., user.IntoReturnUser())` に変更した．


Closes #78 