### PR TITLE
Modify: force https

### DIFF
--- a/router.go
+++ b/router.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+
 	"github.com/labstack/echo"
 	"github.com/labstack/echo/middleware"
 	"github.com/monkukui/procon-qa/handler"
@@ -11,7 +13,10 @@ func newRouter() *echo.Echo {
 
 	e.Use(middleware.Logger())
 	e.Use(middleware.Recover())
-	e.Use(middleware.HTTPSRedirect())
+	// ローカルでテストする時にhttpsにリダイレクトされるのを防ぐ
+	if os.Getenv("STAGE") != "TEST" {
+		e.Use(middleware.HTTPSRedirect())
+	}
 
 	e.Static("/js", "client/dist/js")
 	e.Static("/css", "client/dist/css")

--- a/router.go
+++ b/router.go
@@ -11,6 +11,7 @@ func newRouter() *echo.Echo {
 
 	e.Use(middleware.Logger())
 	e.Use(middleware.Recover())
+	e.Use(middleware.HTTPSRedirect())
 
 	e.Static("/js", "client/dist/js")
 	e.Static("/css", "client/dist/css")


### PR DESCRIPTION
現在httpでもブラウザで開けるようになってしまっているので、セキュリティの観点からhttpでアクセスするとhttpsにリダイレクトするミドルウェアを使うようにしてみました。

ちなみにHeroku側でその機能は提供されていないらしいです。
> Redirects need to be performed at the application level as the Heroku router does not provide this functionality. You should code the redirect logic into your application. Under the hood, Heroku router (over)writes the X-Forwarded-Proto and the X-Forwarded-Port request headers. The app must check X-Forwarded-Proto and respond with a redirect response when it is not https but http.
[Can Heroku force an application to use SSL/TLS?](https://help.heroku.com/J2R1S4T8/can-heroku-force-an-application-to-use-ssl-tls)

また、上の引用でX-Forwarded-Protoをチェックしてねと書いてありますが、middlewareのコードを追ったところ、ちゃんとチェックされていたので期待通りに動くと思います。

https://github.com/labstack/echo/blob/d3245067e0e02dafc7d14e17f5aa612711c30e83/context.go#L258